### PR TITLE
Integrate Fablab local work + salvage unique parts of PR #31

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .routers import datasets, search, export, annotate, jobs, status, rubrics, analyze, taxonomy, nodes, graph, labeling, evaluate, canvas
+from .routers import datasets, search, export, annotate, jobs, status, rubrics, analyze, taxonomy, nodes, graph, labeling, evaluate, canvas, chat
 from .routers.labeling import nodes_router as labeling_nodes_router
 
 app = FastAPI(title="RAG Bloom API", version="0.2.0")
@@ -38,6 +38,7 @@ app.include_router(labeling.router)
 app.include_router(labeling_nodes_router)
 app.include_router(evaluate.router)
 app.include_router(canvas.router)
+app.include_router(chat.router)
 
 @app.get("/health")
 def health():

--- a/backend/app/routers/canvas.py
+++ b/backend/app/routers/canvas.py
@@ -15,6 +15,7 @@ from ..db.session import SessionLocal, get_db
 from ..models.models import Chunk, Dataset, Document, KnowledgeNode
 from ..services import canvas_client as cc
 from ..services.bloom_multilabel import classify_bloom_multilabel
+from ..services.topic_classifier import classify_topic
 from ..services.chunking import split_into_chunks
 from ..services.embedding import embed_texts
 from ..services.embedding_provider import current_embedding_model
@@ -73,8 +74,11 @@ class IngestRequest(BaseModel):
         "files",
     ]
     max_nodes_per_doc: int = 30
+    max_nodes_auto: bool = False
     min_prob: float = 0.2
     max_files: int = 20
+    topic_mode: str = "none"   # "none" | "auto" | "guided"
+    topic_tree: str | None = None  # indented topic tree for guided mode
 
 
 class IngestResponse(BaseModel):
@@ -291,13 +295,17 @@ def _process_document(
     db: Session,
     skipped: list[str],
     module_map: dict[str, dict] | None = None,
+    max_nodes_auto: bool = False,
+    topic_mode: str = "none",
+    topic_tree: str | None = None,
 ) -> ImportedDocumentOut | None:
     raw_text = raw_text.strip()
     if not raw_text:
         skipped.append(f"{source_label}: пустой текст")
         return None
 
-    raw_nodes = extractor.extract(raw_text, max_nodes=max_nodes, min_freq=1)
+    effective_max = 0 if max_nodes_auto else max_nodes
+    raw_nodes = extractor.extract(raw_text, max_nodes=effective_max, min_freq=1)
     if not raw_nodes:
         skipped.append(f"{source_label}: узлы не найдены")
         return None
@@ -334,6 +342,7 @@ def _process_document(
             min_prob=min_prob,
             max_levels=2,
         )
+        topic_meta = classify_topic(ctx, mode=topic_mode, topic_tree=topic_tree) if topic_mode != "none" else None
         module_meta = (module_map or {}).get(source_label)
         model_info = {
             "extractor": extractor.name,
@@ -346,6 +355,7 @@ def _process_document(
             "frequency": node.get("frequency"),
             "node_type": node.get("node_type"),
             "rationale": cls.get("rationale"),
+            **({"topic": topic_meta} if topic_meta else {}),
             **({"module": module_meta} if module_meta else {}),
         }
 
@@ -431,14 +441,24 @@ def _process_document(
     )
 
 
+_courses_cache: dict = {"data": None, "at": 0.0}
+_COURSES_TTL = 300  # seconds
+
+
 @router.get("/courses")
 def list_courses():
+    import time
     _check_canvas_configured()
+    now = time.monotonic()
+    if _courses_cache["data"] is not None and now - _courses_cache["at"] < _COURSES_TTL:
+        return _courses_cache["data"]
     try:
         courses = cc.list_courses()
     except Exception as exc:
+        if _courses_cache["data"] is not None:
+            return _courses_cache["data"]
         raise HTTPException(502, f"Canvas API error: {exc}")
-    return [
+    result = [
         {
             "id": c["id"],
             "name": c["name"],
@@ -448,6 +468,9 @@ def list_courses():
         }
         for c in courses
     ]
+    _courses_cache["data"] = result
+    _courses_cache["at"] = now
+    return result
 
 
 @router.get("/courses/{course_id}/files")
@@ -503,6 +526,9 @@ def ingest_course(payload: IngestRequest, db: Session = Depends(get_db)):
             db,
             skipped,
             module_map=module_map,
+            max_nodes_auto=payload.max_nodes_auto,
+            topic_mode=payload.topic_mode,
+            topic_tree=payload.topic_tree,
         )
         if imported and (imported.nodes_created > 0 or imported.nodes_updated > 0):
             documents.append(imported)
@@ -667,6 +693,9 @@ def ingest_course_stream(payload: IngestRequest, db: Session = Depends(get_db)):
                     gen_db,
                     skipped,
                     module_map=module_map,
+                    max_nodes_auto=payload.max_nodes_auto,
+                    topic_mode=payload.topic_mode,
+                    topic_tree=payload.topic_tree,
                 )
                 if imported and (imported.nodes_created > 0 or imported.nodes_updated > 0):
                     documents.append(imported)

--- a/backend/app/routers/graph.py
+++ b/backend/app/routers/graph.py
@@ -9,7 +9,15 @@ from sqlalchemy import text
 
 from ..db.session import get_db
 from ..models.models import KnowledgeNode, KnowledgeEdge, Job, JobType, JobStatus
-from ..schemas.schemas import GraphOut, GraphNodeOut, GraphEdgeOut, GraphRebuildIn, GraphRebuildOut
+from ..schemas.schemas import (
+    GraphOut,
+    GraphNodeOut,
+    GraphEdgeOut,
+    GraphRebuildIn,
+    GraphRebuildOut,
+    GraphClusterOut,
+    GraphClustersOut,
+)
 from ..utils.bloom import LEVEL_ORDER
 from ..tasks.queue import enqueue_or_mark
 
@@ -352,3 +360,213 @@ def get_zpd(
         "next_level": next_level,
         "suggestions": suggestions,
     }
+
+
+# ---------------------------------------------------------------------------
+# Clustering — collapse similar nodes into groups for large-graph view (>200)
+# ---------------------------------------------------------------------------
+
+class _DSU:
+    """Union-Find / Disjoint Set Union for greedy clustering."""
+
+    def __init__(self, ids: list[int]):
+        self.parent: dict[int, int] = {i: i for i in ids}
+        self.size: dict[int, int] = {i: 1 for i in ids}
+
+    def find(self, x: int) -> int:
+        while self.parent[x] != x:
+            self.parent[x] = self.parent[self.parent[x]]
+            x = self.parent[x]
+        return x
+
+    def union(self, a: int, b: int) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra == rb:
+            return
+        if self.size[ra] < self.size[rb]:
+            ra, rb = rb, ra
+        self.parent[rb] = ra
+        self.size[ra] += self.size[rb]
+
+
+@router.get("/clusters", response_model=GraphClustersOut)
+def get_clusters(
+    dataset_id: int | None = None,
+    document_id: int | None = None,
+    embedding_model: str | None = None,
+    threshold: float = Query(0.55, ge=0.0, le=1.0, description="Min cosine similarity to merge nodes"),
+    top_k: int = Query(8, ge=1, le=50, description="kNN per node when building edges on the fly"),
+    limit_nodes: int = Query(2000, ge=1, le=20000),
+    min_cluster_size: int = Query(1, ge=1, le=100),
+    db: Session = Depends(get_db),
+):
+    """Collapse nodes into clusters of semantically close items.
+
+    Designed for the >200-node regime where rendering every node individually
+    degrades graph performance.  Uses persisted similarity edges when available
+    (faster, deterministic) and falls back to live pgvector kNN otherwise.
+
+    Algorithm: build a similarity graph with edge weight >= ``threshold``, then
+    run Union-Find to obtain connected components.  Each component becomes a
+    cluster.  For every cluster we return:
+
+    * ``representative_title`` — the highest-frequency node title in the
+      component (or first by id if frequencies are equal);
+    * ``dominant_level`` — the Bloom level appearing most often across
+      ``top_levels`` of cluster members;
+    * ``avg_prob_vector`` — element-wise mean of probability vectors,
+      re-normalised to sum to 1.
+    """
+    # --- 1. fetch candidate nodes ----------------------------------------
+    filters = ["kn.vec IS NOT NULL"]
+    params: dict[str, object] = {"limit": limit_nodes}
+    if dataset_id is not None:
+        filters.append("kn.dataset_id = :ds")
+        params["ds"] = dataset_id
+    if document_id is not None:
+        filters.append("kn.document_id = :doc")
+        params["doc"] = document_id
+    if embedding_model is not None:
+        filters.append("kn.embedding_model = :em")
+        params["em"] = embedding_model
+    where_clause = " AND ".join(filters)
+    ids_sql = f"""
+        SELECT kn.id FROM knowledge_nodes kn
+        WHERE {where_clause}
+        ORDER BY kn.id ASC
+        LIMIT :limit
+    """
+    node_ids = [row[0] for row in db.execute(text(ids_sql), params).all()]
+    if not node_ids:
+        return GraphClustersOut(
+            dataset_id=dataset_id,
+            total_nodes=0,
+            total_clusters=0,
+            threshold=threshold,
+            clusters=[],
+        )
+
+    nodes = (
+        db.query(KnowledgeNode)
+        .filter(KnowledgeNode.id.in_(node_ids))
+        .all()
+    )
+    node_by_id = {n.id: n for n in nodes}
+
+    # --- 2. collect similarity edges -------------------------------------
+    edges: list[tuple[int, int, float]] = []
+
+    # 2a. persisted edges (preferred)
+    method_filters = [KnowledgeEdge.method.like("similarity|%")]
+    persisted_rows = (
+        db.query(KnowledgeEdge.from_node_id, KnowledgeEdge.to_node_id, KnowledgeEdge.weight)
+        .filter(
+            KnowledgeEdge.from_node_id.in_(node_ids),
+            KnowledgeEdge.to_node_id.in_(node_ids),
+            or_(*method_filters),
+            KnowledgeEdge.weight >= threshold,
+        )
+        .all()
+    )
+    for a, b, w in persisted_rows:
+        edges.append((int(a), int(b), float(w)))
+
+    # 2b. fall back to live pgvector kNN when no persisted edges
+    if not edges:
+        in_clause_params: dict[str, object] = {"k": top_k, "threshold": threshold}
+        ds_filter = ""
+        if dataset_id is not None:
+            ds_filter = "AND kn2.dataset_id = :ds"
+            in_clause_params["ds"] = dataset_id
+        sql = text(f"""
+            SELECT kn2.id AS node_id,
+                   1.0 - (kn2.vec <=> (SELECT vec FROM knowledge_nodes WHERE id = :id)) AS score
+            FROM knowledge_nodes kn2
+            WHERE kn2.id != :id
+              AND kn2.vec IS NOT NULL
+              {ds_filter}
+            ORDER BY kn2.vec <=> (SELECT vec FROM knowledge_nodes WHERE id = :id)
+            LIMIT :k
+        """)
+        for node_id in node_ids:
+            p = dict(in_clause_params)
+            p["id"] = node_id
+            rows = db.execute(sql, p).mappings().all()
+            for row in rows:
+                score = float(row["score"])
+                if score < threshold:
+                    continue
+                edges.append((node_id, int(row["node_id"]), score))
+
+    # --- 3. Union-Find ----------------------------------------------------
+    dsu = _DSU(node_ids)
+    for a, b, _w in edges:
+        if a in node_by_id and b in node_by_id:
+            dsu.union(a, b)
+
+    # --- 4. group nodes by root ------------------------------------------
+    groups: dict[int, list[int]] = defaultdict(list)
+    for nid in node_ids:
+        groups[dsu.find(nid)].append(nid)
+
+    # --- 5. summarise each cluster ---------------------------------------
+    out: list[GraphClusterOut] = []
+    for cid, (root, member_ids) in enumerate(sorted(groups.items(), key=lambda kv: -len(kv[1]))):
+        if len(member_ids) < min_cluster_size:
+            continue
+        members = [node_by_id[m] for m in member_ids if m in node_by_id]
+        if not members:
+            continue
+
+        # representative — highest frequency, ties → smallest id
+        def _freq(n: KnowledgeNode) -> int:
+            mi = n.model_info or {}
+            f = mi.get("frequency") if isinstance(mi, dict) else None
+            try:
+                return int(f) if f is not None else 1
+            except (TypeError, ValueError):
+                return 1
+        rep = max(members, key=lambda n: (_freq(n), -n.id))
+
+        # dominant Bloom level across top_levels
+        level_counts: dict[str, int] = defaultdict(int)
+        for n in members:
+            for lvl in (n.top_levels or []):
+                level_counts[str(lvl)] += 1
+        dominant_level = max(level_counts.items(), key=lambda kv: kv[1])[0] if level_counts else None
+
+        # average prob vector (mean, then renormalise to sum=1)
+        avg = [0.0] * 6
+        denom = 0
+        for n in members:
+            pv = list(n.prob_vector or [])
+            if len(pv) == 6:
+                for i, p in enumerate(pv):
+                    avg[i] += float(p)
+                denom += 1
+        if denom > 0:
+            avg = [x / denom for x in avg]
+            s = sum(avg)
+            if s > 0:
+                avg = [round(x / s, 4) for x in avg]
+        else:
+            avg = [round(1 / 6, 4)] * 6
+
+        sample = [n.title for n in sorted(members, key=lambda n: (-_freq(n), n.id))[:5]]
+        out.append(GraphClusterOut(
+            cluster_id=cid,
+            size=len(members),
+            member_ids=[n.id for n in members],
+            representative_title=rep.title,
+            dominant_level=dominant_level if dominant_level in {"remember","understand","apply","analyze","evaluate","create"} else None,
+            avg_prob_vector=avg,
+            sample_titles=sample,
+        ))
+
+    return GraphClustersOut(
+        dataset_id=dataset_id,
+        total_nodes=len(node_ids),
+        total_clusters=len(out),
+        threshold=threshold,
+        clusters=out,
+    )

--- a/backend/app/routers/nodes.py
+++ b/backend/app/routers/nodes.py
@@ -13,6 +13,7 @@ from ..schemas.schemas import (
     KnowledgeNodeSearchHit,
     KnowledgeNodeUpdateIn,
 )
+from ..services.embedding import embed_texts
 from ..services.embedding_provider import current_embedding_model
 from ..services.query_embed import embed_query
 from ..services.bloom_multilabel import classify_bloom_multilabel

--- a/backend/app/schemas/schemas.py
+++ b/backend/app/schemas/schemas.py
@@ -316,3 +316,22 @@ class GraphRebuildIn(BaseModel):
 
 class GraphRebuildOut(BaseModel):
     job_id: int
+
+
+class GraphClusterOut(BaseModel):
+    """Single cluster summary for collapsed-graph view (>200 nodes)."""
+    cluster_id: int
+    size: int
+    member_ids: List[int]
+    representative_title: str
+    dominant_level: Optional[BloomLevel] = None
+    avg_prob_vector: List[float]
+    sample_titles: List[str]
+
+
+class GraphClustersOut(BaseModel):
+    dataset_id: Optional[int] = None
+    total_nodes: int
+    total_clusters: int
+    threshold: float
+    clusters: List[GraphClusterOut]

--- a/backend/app/services/bloom_multilabel.py
+++ b/backend/app/services/bloom_multilabel.py
@@ -48,7 +48,7 @@ def classify_bloom_multilabel(
 
     prompt = build_bloom_multilabel_prompt(text, rubric=rubric)
     try:
-        js = chat_completion_json(model, prompt, max_tokens=450)
+        js = chat_completion_json(model, prompt, max_tokens=1200)
     except Exception:
         # Network timeout, rate-limit, etc. — degrade gracefully to keyword classifier
         return keyword_classify(text, min_prob=min_prob, max_levels=max_levels)

--- a/backend/app/services/openai_client.py
+++ b/backend/app/services/openai_client.py
@@ -12,7 +12,9 @@ def _base() -> str:
 
 def extract_json_block(text: str) -> str:
     """Возвращает JSON-строку из content: ищет ```json ... ``` или первую валидную JSON-структуру."""
-    t = text.strip()
+    import re as _re
+    # Strip Qwen3 chain-of-thought tags
+    t = _re.sub(r"<think>.*?</think>", "", text, flags=_re.DOTALL).strip()
     if "```" in t:
         parts = t.split("```")
         for i in range(len(parts) - 1):
@@ -25,11 +27,20 @@ def extract_json_block(text: str) -> str:
                 return block
             except Exception:
                 pass
-    for s in (t,):
-        s = s.strip()
+    # Try whole text
+    try:
+        json.loads(t)
+        return t
+    except Exception:
+        pass
+    # Try to find first {...} block
+    start = t.find("{")
+    end = t.rfind("}")
+    if start != -1 and end > start:
+        candidate = t[start:end + 1]
         try:
-            json.loads(s)
-            return s
+            json.loads(candidate)
+            return candidate
         except Exception:
             pass
     raise ValueError("No JSON payload found in LLM response")
@@ -43,9 +54,10 @@ def chat_completion_json(model: str, prompt: str, max_tokens: int = 400) -> str:
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
+    # /no_think disables Qwen3 chain-of-thought to avoid multi-minute delays
     payload = {
         "model": model,
-        "messages": [{"role": "user", "content": prompt}],
+        "messages": [{"role": "user", "content": "/no_think\n" + prompt}],
         "temperature": 0.2,
         "max_tokens": max_tokens,
     }
@@ -53,6 +65,47 @@ def chat_completion_json(model: str, prompt: str, max_tokens: int = 400) -> str:
     resp.raise_for_status()
     content = resp.json()["choices"][0]["message"]["content"]
     return extract_json_block(content)
+
+
+def chat_completion_stream(
+    model: str,
+    messages: list[dict],
+    max_tokens: int = 1024,
+):
+    """Yields text chunks from a streaming chat completion."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is empty")
+    url = f"{_base()}/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": model,
+        "messages": messages,
+        "temperature": 0.3,
+        "max_tokens": max_tokens,
+        "stream": True,
+    }
+    with requests.post(url, headers=headers, json=payload, stream=True, timeout=OPENAI_TIMEOUT) as resp:
+        resp.raise_for_status()
+        for raw_line in resp.iter_lines():
+            if not raw_line:
+                continue
+            line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
+            if line.startswith("data: "):
+                data = line[6:]
+                if data.strip() == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data)
+                    delta = chunk["choices"][0].get("delta", {})
+                    text = delta.get("content") or ""
+                    if text:
+                        yield text
+                except Exception:
+                    continue
 
 
 def embeddings(model: str, inputs: list[str]) -> list[list[float]]:

--- a/backend/app/services/topic_classifier.py
+++ b/backend/app/services/topic_classifier.py
@@ -1,0 +1,96 @@
+"""
+Topic classifier: assigns subject/topic/subtopic hierarchy to a text fragment.
+
+Two modes:
+  auto   — LLM freely infers the topic hierarchy from the text
+  guided — LLM classifies against a user-supplied topic tree
+"""
+import os
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_AUTO_PROMPT = """\
+Ты — ассистент по анализу образовательного контента.
+Определи, к какому разделу учебной дисциплины относится следующий текст.
+
+Верни ТОЛЬКО JSON-объект (без пояснений):
+{{
+  "subject": "название дисциплины или предмета (1-3 слова)",
+  "topic": "раздел/тема внутри дисциплины (1-5 слов)",
+  "subtopic": "конкретная подтема или null если не применимо (1-5 слов)"
+}}
+
+ТЕКСТ:
+{text}
+"""
+
+_GUIDED_PROMPT = """\
+Ты — ассистент по анализу образовательного контента.
+Определи, к какому разделу из приведённого дерева тем относится следующий текст.
+Выбирай ТОЛЬКО из предложенного дерева. Если текст не подходит ни к одной теме, укажи ближайшую.
+
+ДЕРЕВО ТЕМ:
+{tree}
+
+Верни ТОЛЬКО JSON-объект (без пояснений):
+{{
+  "subject": "верхний уровень из дерева",
+  "topic": "второй уровень из дерева или null",
+  "subtopic": "третий уровень из дерева или null"
+}}
+
+ТЕКСТ:
+{text}
+"""
+
+
+def _call_llm(prompt: str) -> dict[str, Any] | None:
+    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    model = os.getenv("LLM_MODEL", "gpt-4o-mini")
+    if not api_key:
+        return None
+    try:
+        from .openai_client import chat_completion_json
+        js = chat_completion_json(model, prompt, max_tokens=200)
+        data = json.loads(js)
+        if not isinstance(data, dict):
+            return None
+        return {
+            "subject": str(data.get("subject") or "").strip() or None,
+            "topic": str(data.get("topic") or "").strip() or None,
+            "subtopic": str(data.get("subtopic") or "").strip() or None,
+        }
+    except Exception as exc:
+        logger.warning("topic_classifier failed: %s", exc)
+        return None
+
+
+def classify_topic_auto(text: str) -> dict[str, Any] | None:
+    """Freely infer subject/topic/subtopic from text."""
+    prompt = _AUTO_PROMPT.format(text=text[:2000])
+    return _call_llm(prompt)
+
+
+def classify_topic_guided(text: str, topic_tree: str) -> dict[str, Any] | None:
+    """Classify text against a user-supplied topic tree (plain indented text)."""
+    prompt = _GUIDED_PROMPT.format(tree=topic_tree[:3000], text=text[:2000])
+    return _call_llm(prompt)
+
+
+def classify_topic(
+    text: str,
+    mode: str,
+    topic_tree: str | None = None,
+) -> dict[str, Any] | None:
+    """
+    mode: 'auto' | 'guided' | 'none'
+    topic_tree: indented text tree, required when mode='guided'
+    """
+    if mode == "auto":
+        return classify_topic_auto(text)
+    if mode == "guided" and topic_tree:
+        return classify_topic_guided(text, topic_tree)
+    return None

--- a/data/eval_report.json
+++ b/data/eval_report.json
@@ -1,0 +1,11 @@
+{
+  "samples": 109,
+  "hamming_loss": 0.1621,
+  "f1_micro": 0.6294,
+  "f1_macro": 0.6402,
+  "min_prob": 0.2,
+  "max_levels": 2,
+  "from_db": false,
+  "dataset_id": null,
+  "annotator": null
+}

--- a/data/eval_report_full.json
+++ b/data/eval_report_full.json
@@ -1,0 +1,45 @@
+{
+  "samples": 109,
+  "hamming_loss": 0.1621,
+  "f1_micro": 0.6294,
+  "f1_macro": 0.6403,
+  "cohen_kappa_macro": 0.5426,
+  "per_level": {
+    "remember": {
+      "support": 19,
+      "precision": 0.56,
+      "recall": 0.737,
+      "f1": 0.636
+    },
+    "understand": {
+      "support": 23,
+      "precision": 0.438,
+      "recall": 0.913,
+      "f1": 0.592
+    },
+    "apply": {
+      "support": 19,
+      "precision": 0.394,
+      "recall": 0.684,
+      "f1": 0.5
+    },
+    "analyze": {
+      "support": 24,
+      "precision": 0.867,
+      "recall": 0.542,
+      "f1": 0.667
+    },
+    "evaluate": {
+      "support": 23,
+      "precision": 0.8,
+      "recall": 0.696,
+      "f1": 0.744
+    },
+    "create": {
+      "support": 17,
+      "precision": 0.65,
+      "recall": 0.765,
+      "f1": 0.703
+    }
+  }
+}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -8,6 +8,13 @@ const nextConfig = {
       },
     ];
   },
+  // Increase proxy timeout to 90s for slow Canvas API responses
+  httpAgentOptions: {
+    keepAlive: true,
+  },
+  experimental: {
+    proxyTimeout: 90000,
+  },
 };
 
 export default nextConfig;

--- a/scripts/_eval_perlevel.py
+++ b/scripts/_eval_perlevel.py
@@ -1,0 +1,82 @@
+"""Extended evaluation: per-level precision/recall/F1 + Cohen kappa."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.app.services.bloom_multilabel import classify_bloom_multilabel
+
+LEVELS = ["remember", "understand", "apply", "analyze", "evaluate", "create"]
+
+
+def vectorize(labels):
+    s = set(labels)
+    return [1 if lvl in s else 0 for lvl in LEVELS]
+
+
+def main():
+    data_path = Path("data/bloom_dataset.jsonl")
+    items = [json.loads(ln) for ln in data_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+    y_true, y_pred = [], []
+    for it in items:
+        if not it.get("text"):
+            continue
+        res = classify_bloom_multilabel(it["text"], min_prob=0.2, max_levels=2)
+        y_true.append(vectorize(it["labels"]))
+        y_pred.append(vectorize(res["top_levels"]))
+
+    per_level = {}
+    for i, lvl in enumerate(LEVELS):
+        tp = sum(1 for t, p in zip(y_true, y_pred) if t[i] == 1 and p[i] == 1)
+        fp = sum(1 for t, p in zip(y_true, y_pred) if t[i] == 0 and p[i] == 1)
+        fn = sum(1 for t, p in zip(y_true, y_pred) if t[i] == 1 and p[i] == 0)
+        support = sum(1 for t in y_true if t[i] == 1)
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        recall = tp / (tp + fn) if (tp + fn) else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+        per_level[lvl] = {
+            "support": support,
+            "precision": round(precision, 3),
+            "recall": round(recall, 3),
+            "f1": round(f1, 3),
+        }
+
+    # Cohen kappa (per-level, then averaged)
+    kappas = []
+    n = len(y_true)
+    for i in range(6):
+        po = sum(1 for t, p in zip(y_true, y_pred) if t[i] == p[i]) / n
+        p1_true = sum(t[i] for t in y_true) / n
+        p1_pred = sum(p[i] for p in y_pred) / n
+        pe = p1_true * p1_pred + (1 - p1_true) * (1 - p1_pred)
+        if pe >= 1:
+            kappas.append(1.0 if po >= 1 else 0.0)
+        else:
+            kappas.append((po - pe) / (1 - pe))
+    kappa_macro = sum(kappas) / len(kappas)
+
+    # global metrics
+    tp = sum(1 for t, p in zip(y_true, y_pred) for tv, pv in zip(t, p) if tv == 1 and pv == 1)
+    fp = sum(1 for t, p in zip(y_true, y_pred) for tv, pv in zip(t, p) if tv == 0 and pv == 1)
+    fn = sum(1 for t, p in zip(y_true, y_pred) for tv, pv in zip(t, p) if tv == 1 and pv == 0)
+    f1_micro = 2 * tp / (2 * tp + fp + fn) if (2 * tp + fp + fn) else 0.0
+    hamming = sum(1 for t, p in zip(y_true, y_pred) for tv, pv in zip(t, p) if tv != pv) / (n * 6)
+
+    out = {
+        "samples": n,
+        "hamming_loss": round(hamming, 4),
+        "f1_micro": round(f1_micro, 4),
+        "f1_macro": round(sum(v["f1"] for v in per_level.values()) / 6, 4),
+        "cohen_kappa_macro": round(kappa_macro, 4),
+        "per_level": per_level,
+    }
+    print(json.dumps(out, ensure_ascii=False, indent=2))
+    Path("data/eval_report_full.json").write_text(json.dumps(out, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_graph_clusters.py
+++ b/tests/test_graph_clusters.py
@@ -1,0 +1,67 @@
+"""Unit tests for the graph clustering Union-Find algorithm.
+
+These tests do not require a running database — they exercise the pure
+algorithmic core (_DSU) imported from the router module.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_dsu_singleton_clusters():
+    from backend.app.routers.graph import _DSU
+    dsu = _DSU([1, 2, 3, 4, 5])
+    roots = {dsu.find(i) for i in [1, 2, 3, 4, 5]}
+    assert len(roots) == 5, "Without unions every node is its own cluster"
+
+
+def test_dsu_chain_union():
+    from backend.app.routers.graph import _DSU
+    dsu = _DSU([1, 2, 3, 4])
+    dsu.union(1, 2)
+    dsu.union(2, 3)
+    # 1-2-3 merged, 4 separate
+    assert dsu.find(1) == dsu.find(2) == dsu.find(3)
+    assert dsu.find(4) != dsu.find(1)
+    assert dsu.size[dsu.find(1)] == 3
+
+
+def test_dsu_two_components():
+    from backend.app.routers.graph import _DSU
+    ids = list(range(10))
+    dsu = _DSU(ids)
+    # component A: 0-1-2-3
+    for a, b in [(0, 1), (1, 2), (2, 3)]:
+        dsu.union(a, b)
+    # component B: 4-5-6
+    for a, b in [(4, 5), (5, 6)]:
+        dsu.union(a, b)
+    # 7, 8, 9 stay isolated
+    roots = {dsu.find(i) for i in ids}
+    assert len(roots) == 5  # 2 multi-node + 3 singleton
+
+
+def test_dsu_redundant_union_is_safe():
+    from backend.app.routers.graph import _DSU
+    dsu = _DSU([1, 2])
+    dsu.union(1, 2)
+    dsu.union(1, 2)  # idempotent
+    dsu.union(2, 1)  # symmetric
+    assert dsu.find(1) == dsu.find(2)
+    assert dsu.size[dsu.find(1)] == 2
+
+
+def test_dsu_handles_path_compression():
+    """Long chain should still resolve in roughly O(1) after compression."""
+    from backend.app.routers.graph import _DSU
+    n = 100
+    dsu = _DSU(list(range(n)))
+    for i in range(n - 1):
+        dsu.union(i, i + 1)
+    root = dsu.find(0)
+    for i in range(n):
+        assert dsu.find(i) == root
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Что это
Сводит несохранённую локальную работу со второй машины (Fablab) поверх свежего `main`
(после #29/#30) и переносит из PR #31 только то, что ещё не в main.

## Коммиты
- **Fablab local** — topic_classifier (subject→topic→subtopic через LLM) + интеграция в
  Canvas-ingest; поддержка локального Qwen3 в openai_client (срез `<think>`, `/no_think`,
  стриминг, устойчивый парсинг JSON); кэш `/courses` (5 мин) + `proxyTimeout` 90с;
  bloom max_tokens 450→1200. Плюс два фикса багов на main: незарегистрированный chat-роутер
  и отсутствующий импорт `embed_texts` в nodes.py.
- **/graph/clusters** — Union-Find для регламента >200 узлов (из PR #31).
- **eval** — gold-отчёты + scripts/_eval_perlevel.py (из PR #31).

## Сознательно НЕ взято
UI-файлы (index.tsx, css), docker-compose, tsconfig — локальная версия была просто
старее main (откатывала dashboard, expertMode, переключатель языка). Эти правки Fablab —
регрессии, а не новые фичи.

## Бэкап
Полный снимок исходного несохранённого состояния — в ветке
`backup/local-fablab-20260601-095337` (commit 808fc83).

Closes #31

